### PR TITLE
Add endpoints for system info and apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,25 @@ Instead of `KEYCODE`, you should write an actual keycode. These are the availabl
 | Menu | `menu` | Opens options menu |
 | Volume up | `volumeup` | Increases volume by 1 |
 | Volume down | `volumedown` | Decreases volume by 1 |
+
+### Additional controller endpoints
+
+#### Get system information
+`http://TV_IP:6095/controller?action=getsysteminfo`
+
+Returns a JSON object containing information like device ID and MAC addresses.
+
+#### Capture screen
+`http://TV_IP:6095/controller?action=capturescreen`
+
+Returns a binary screenshot of the current screen.
+
+#### Get installed applications
+`http://TV_IP:6095/controller?action=getinstalledapp&count=999&changeIcon=1`
+
+Provides a JSON list of installed applications along with icon URLs.
+
+#### Start an application
+`http://TV_IP:6095/controller?action=startapp&type=packagename&packagename=PACKAGE_NAME`
+
+Starts the specified application on the TV.

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,14 @@ Documentation
 -------------
 You can find the documentation on Github here_.
 
+Additional controller endpoints
+------------------------------
+
+- ``/controller?action=getsysteminfo`` returns system information in JSON
+- ``/controller?action=capturescreen`` grabs a screenshot in binary form
+- ``/controller?action=getinstalledapp&count=999&changeIcon=1`` lists installed apps
+- ``/controller?action=startapp&type=packagename&packagename=PACKAGE`` starts a package
+
 
 .. _one.: http://www.mi.com/en/mitv3s/65/
 .. _here: https://github.com/fattdev/pymitv

--- a/pymitv/control.py
+++ b/pymitv/control.py
@@ -95,3 +95,43 @@ class Control:
 
         volume = json.loads(request.json()['data'])['volum']
         return volume
+
+    @staticmethod
+    def get_system_info(ip_address):
+        """Return system information for the TV."""
+        tv_url = 'http://{}:6095/controller?action=getsysteminfo'.format(ip_address)
+        request = requests.get(tv_url)
+        if request.status_code != 200:
+            return None
+        return request.json()
+
+    @staticmethod
+    def capture_screen(ip_address):
+        """Capture the current TV screen and return the raw response."""
+        tv_url = 'http://{}:6095/controller?action=capturescreen'.format(ip_address)
+        request = requests.get(tv_url)
+        if request.status_code != 200:
+            return None
+        return request.content
+
+    @staticmethod
+    def get_installed_apps(ip_address, count=999, change_icon=1):
+        """Return list of installed applications."""
+        tv_url = (
+            'http://{}:6095/controller?action=getinstalledapp&count={}&changeIcon={}'
+        ).format(ip_address, count, change_icon)
+        request = requests.get(tv_url)
+        if request.status_code != 200:
+            return None
+        return request.json()
+
+    @staticmethod
+    def start_app(ip_address, package_name, app_type='packagename'):
+        """Start an application on the TV."""
+        tv_url = (
+            'http://{}:6095/controller?action=startapp&type={}&packagename={}'
+        ).format(ip_address, app_type, package_name)
+        request = requests.get(tv_url)
+        if request.status_code != 200:
+            return False
+        return True

--- a/pymitv/control.py
+++ b/pymitv/control.py
@@ -7,7 +7,7 @@ import requests
 
 
 class Control:
-    """A virtual remove control for the TV."""
+    """A virtual remote control for the TV."""
     turn_on = ['power']
     turn_off = ['power']
     sleep = ['power', 'wait', 'right', 'wait', 'right', 'wait', 'enter']

--- a/pymitv/tv.py
+++ b/pymitv/tv.py
@@ -124,6 +124,22 @@ using any of the polyfill controls, could produce weird results.')
         """Mutes the TV."""
         return Control().mute(self.ip_address)
 
+    def get_system_info(self):
+        """Retrieve system information from the TV."""
+        return Control().get_system_info(self.ip_address)
+
+    def capture_screen(self):
+        """Capture the current screen as bytes."""
+        return Control().capture_screen(self.ip_address)
+
+    def get_installed_apps(self, count=999, change_icon=1):
+        """Get list of installed applications."""
+        return Control().get_installed_apps(self.ip_address, count, change_icon)
+
+    def start_app(self, package_name, app_type='packagename'):
+        """Start an application identified by its package name."""
+        return Control().start_app(self.ip_address, package_name, app_type)
+
     def set_source(self, source):
         """Selects and saves source."""
         route = Navigator(source=self.source).navigate_to_source(source)


### PR DESCRIPTION
## Summary
- support more MiTV controller endpoints
- document new API calls

## Testing
- `pylint pymitv`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68453ab34a608320a377b424279f2d67

## Summary by Sourcery

Introduce new controller endpoints for fetching system information, capturing the screen, listing installed apps, and launching apps, and expose them via the TV wrapper class

New Features:
- Add get_system_info endpoint to retrieve TV system details
- Add capture_screen endpoint to capture and return a screenshot
- Add get_installed_apps endpoint to list installed applications
- Add start_app endpoint to launch an application by package name
- Expose all new Control endpoints as methods on the TV class

Documentation:
- Document the new controller endpoints in README.md