### PR TITLE
Add isort & flake8 workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,26 @@
+name: Code Quality
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+      - name: Check imports with isort
+        run: |
+          isort --check-only src tests setup.py
+      - name: Run flake8
+        run: |
+          flake8 src tests setup.py

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ https://github.com/pypa/sampleproject
 from codecs import open
 from os import path
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 # To use a consistent encoding
 here = path.abspath(path.dirname(__file__))

--- a/src/pymitv4/__init__.py
+++ b/src/pymitv4/__init__.py
@@ -2,7 +2,7 @@
 It can connect to Xiaomi TVs and control them."""
 
 
-from pymitv4.discover import Discover
 from pymitv4.control import Control
+from pymitv4.discover import Discover
 from pymitv4.navigator import Navigator
 from pymitv4.tv import TV

--- a/src/pymitv4/control.py
+++ b/src/pymitv4/control.py
@@ -1,6 +1,7 @@
 """The ``pymitv4.control`` module sends keystrokes to the TV."""
-import time
 import json
+import time
+
 import requests
 
 

--- a/src/pymitv4/discover.py
+++ b/src/pymitv4/discover.py
@@ -1,5 +1,6 @@
 """The ``pymitv4.discover`` module handles discovery of local TVs."""
 import socket
+
 import requests
 
 

--- a/src/pymitv4/tv.py
+++ b/src/pymitv4/tv.py
@@ -1,6 +1,5 @@
 """Contains the class for interfacing with the TV."""
-from pymitv4 import Control
-from pymitv4 import Navigator
+from pymitv4 import Control, Navigator
 
 
 class TV:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run isort and flake8 on pushes and PRs
- fix import order so isort passes

## Testing
- `isort --check-only src tests setup.py && flake8 src tests setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6855dd0b5fc483209093d71ce8b79ee2

## Summary by Sourcery

Add a CI workflow for code quality checks using isort and flake8, and adjust imports across the codebase to satisfy linting.

Enhancements:
- Fix import ordering in setup.py and Python modules for isort compliance.

CI:
- Configure GitHub Actions to run isort and flake8 on pushes and pull requests.