### PR TITLE
Fix flake8 issues

### DIFF
--- a/src/pymitv4/__init__.py
+++ b/src/pymitv4/__init__.py
@@ -6,3 +6,5 @@ from pymitv4.control import Control
 from pymitv4.discover import Discover
 from pymitv4.navigator import Navigator
 from pymitv4.tv import TV
+
+__all__ = ["Control", "Discover", "Navigator", "TV"]

--- a/src/pymitv4/control.py
+++ b/src/pymitv4/control.py
@@ -28,7 +28,9 @@ class Control:
     @staticmethod
     def send_keystrokes(ip_address, keystrokes, wait=False):
         """Connects to TV and sends keystroke via HTTP."""
-        tv_url = 'http://{}:6095/controller?action=keyevent&keycode='.format(ip_address)
+        tv_url = (
+            f"http://{ip_address}:6095/controller?action=keyevent&keycode="
+        )
 
         for keystroke in keystrokes:
             if keystroke == 'wait' or wait is True:
@@ -45,7 +47,9 @@ class Control:
     @staticmethod
     def change_source(ip_address, source):
         """Select source hdmi1 or hdmi2"""
-        tv_url = 'http://{}:6095/controller?action=changesource&source='.format(ip_address)
+        tv_url = (
+            f"http://{ip_address}:6095/controller?action=changesource&source="
+        )
         source = source
         request = requests.get(tv_url + source)
         if request.status_code != 200:
@@ -56,7 +60,9 @@ class Control:
     @staticmethod
     def mute(ip_address):
         """Polyfill for muting the TV."""
-        tv_url = 'http://{}:6095/controller?action=keyevent&keycode='.format(ip_address)
+        tv_url = (
+            f"http://{ip_address}:6095/controller?action=keyevent&keycode="
+        )
 
         count = 0
         while count > 30:
@@ -74,9 +80,12 @@ class Control:
         request_timeout = 0.1
 
         try:
-            tv_url = 'http://{}:6095/request?action=isalive'.format(ip_address)
+            tv_url = f"http://{ip_address}:6095/request?action=isalive"
             requests.get(tv_url, timeout=request_timeout)
-        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
+        except (
+            requests.exceptions.ConnectTimeout,
+            requests.exceptions.ConnectionError,
+        ):
             return False
 
         return True
@@ -87,9 +96,12 @@ class Control:
         request_timeout = 0.1
 
         try:
-            tv_url = 'http://{}:6095/general?action=getVolum'.format(ip_address)
+            tv_url = f"http://{ip_address}:6095/general?action=getVolum"
             request = requests.get(tv_url, timeout=request_timeout)
-        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
+        except (
+            requests.exceptions.ConnectTimeout,
+            requests.exceptions.ConnectionError,
+        ):
             return False
 
         volume = json.loads(request.json()['data'])['volum']
@@ -98,7 +110,7 @@ class Control:
     @staticmethod
     def get_system_info(ip_address):
         """Return system information for the TV."""
-        tv_url = 'http://{}:6095/controller?action=getsysteminfo'.format(ip_address)
+        tv_url = f"http://{ip_address}:6095/controller?action=getsysteminfo"
         request = requests.get(tv_url)
         if request.status_code != 200:
             return None
@@ -107,7 +119,7 @@ class Control:
     @staticmethod
     def capture_screen(ip_address):
         """Capture the current TV screen and return the raw response."""
-        tv_url = 'http://{}:6095/controller?action=capturescreen'.format(ip_address)
+        tv_url = f"http://{ip_address}:6095/controller?action=capturescreen"
         request = requests.get(tv_url)
         if request.status_code != 200:
             return None
@@ -117,8 +129,9 @@ class Control:
     def get_installed_apps(ip_address, count=999, change_icon=1):
         """Return list of installed applications."""
         tv_url = (
-            'http://{}:6095/controller?action=getinstalledapp&count={}&changeIcon={}'
-        ).format(ip_address, count, change_icon)
+            f"http://{ip_address}:6095/controller?"
+            f"action=getinstalledapp&count={count}&changeIcon={change_icon}"
+        )
         request = requests.get(tv_url)
         if request.status_code != 200:
             return None

--- a/src/pymitv4/discover.py
+++ b/src/pymitv4/discover.py
@@ -40,14 +40,17 @@ class Discover:
 
     @staticmethod
     def check_ip(ip_address, log=False, request_timeout=0.1):
-        """Attempts a connection to the TV and checks if there really is a TV."""
+        """Attempt a connection to the TV and ensure it exists."""
         if log:
             print('Checking ip: {}...'.format(ip_address))
 
         try:
-            tv_url = 'http://{}:6095/request?action=isalive'.format(ip_address)
+            tv_url = f"http://{ip_address}:6095/request?action=isalive"
             request = requests.get(tv_url, timeout=request_timeout)
-        except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError):
+        except (
+            requests.exceptions.ConnectTimeout,
+            requests.exceptions.ConnectionError,
+        ):
             return False
 
         return request.status_code == 200

--- a/src/pymitv4/tv.py
+++ b/src/pymitv4/tv.py
@@ -3,19 +3,29 @@ from pymitv4 import Control, Navigator
 
 
 class TV:
-    """A virtual representation of the TV that stores state, and takes controls."""
+    """A representation of the TV that stores state and handles controls."""
     ip_address = None
     state = True
     source = None
 
-    def __init__(self, ip_address=None, source=None, initialized=True, assume_state=True):
+    def __init__(
+        self,
+        ip_address=None,
+        source=None,
+        initialized=True,
+        assume_state=True,
+    ):
         # Check if an IP address has been supplied to the constructor
         if ip_address is None:
             print('No TV supplied, hence it won\'t work')
 
         # Check if TV has been initialized for pymitv4 control
         if initialized is False:
-            print("If the TV hasn't been setup for full pymitv4 control, using any of the polyfill controls could produce weird results.")
+            print(
+                "If the TV hasn't been setup for full pymitv4 control, "
+                "using any of the polyfill controls could produce weird "
+                "results."
+            )
 
         # Make IP address global regardless of value
         self.ip_address = ip_address
@@ -38,7 +48,7 @@ class TV:
         return Control().send_keystrokes(self.ip_address, keystroke, wait)
 
         # Send True regardless of whether or not command was sent
-        #return True
+        # return True
 
     def change_source(self, source):
         """Change source of xiaomi tv"""
@@ -132,7 +142,11 @@ class TV:
 
     def get_installed_apps(self, count=999, change_icon=1):
         """Get list of installed applications."""
-        return Control().get_installed_apps(self.ip_address, count, change_icon)
+        return Control().get_installed_apps(
+            self.ip_address,
+            count,
+            change_icon,
+        )
 
     def start_app(self, package_name, app_type='packagename'):
         """Start an application identified by its package name."""


### PR DESCRIPTION
## Summary
- clean up package exports
- reformat HTTP URL constructions
- improve discovery helper and tv class formatting

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855de2e6de88320847aec10dfeedb90

## Summary by Sourcery

Enforce consistent code style and clean up package exports for flake8 compliance

Enhancements:
- Standardize HTTP URL constructions to use f-strings in control and discover modules
- Reformat multi-line statements and exception blocks for improved readability
- Adjust TV class initializer and docstring formatting for clarity
- Add __all__ in __init__.py to explicitly define public API exports