### PR TITLE
Add tests and coverage workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+          pip install .
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=src/pymitv4 --cov-report=xml --cov-report=term
+      - name: Generate coverage badge
+        run: |
+          coverage-badge -o coverage.svg -f
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            coverage.svg

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A Python 3 based control for Xiaomi TV 4
 
 ![Xiaomi TV 4](https://i.imgur.com/kOLWhWU.jpg)
+![coverage](coverage.svg)
 
 ## Introduction
 This package was developed to interface with the Xiaomi TV 4 series through their local HTTP API using Python. The package has both the ability to discover TVs and control them. Support for the previous Xiaomi TV 3 series is no longer guaranteed.

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#fe7d37" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">55%</text>
+        <text x="80" y="14">55%</text>
+    </g>
+</svg>

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,6 @@
 isort
 flake8
 pytest
+coverage
+coverage-badge
+pytest-cov

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Ensure src directory is on path for tests
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,0 +1,30 @@
+from pymitv4.control import Control
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, data='{"volum":10}'):
+        self.status_code = status_code
+        self._data = data
+
+    def json(self):
+        return {"data": self._data}
+
+
+def test_get_volume_success(monkeypatch):
+    def fake_get(url, timeout):
+        return DummyResponse(200, '{"volum":5}')
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    assert Control.get_volume("1.2.3.4") == 5
+
+
+def test_get_volume_failure(monkeypatch):
+    def fake_get(url, timeout):
+        from requests.exceptions import ConnectionError
+
+        raise ConnectionError()
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    assert Control.get_volume("1.2.3.4") is False

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,30 @@
+from pymitv4.discover import Discover
+
+
+class DummyResponse:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+        self._json = {"data": "{}"}
+
+    def json(self):
+        return self._json
+
+
+def test_check_ip_success(monkeypatch):
+    def fake_get(url, timeout):
+        return DummyResponse(200)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    assert Discover.check_ip("1.2.3.4") is True
+
+
+def test_check_ip_failure(monkeypatch):
+    def fake_get(url, timeout):
+        from requests.exceptions import ConnectionError
+
+        raise ConnectionError("connection error")
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    assert Discover.check_ip("1.2.3.4") is False

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -1,0 +1,15 @@
+from pymitv4.navigator import Navigator
+
+
+def test_navigate_without_source():
+    nav = Navigator()
+    route = nav.navigate_to_source("hdmi2")
+    expected = nav.OPEN_SOURCES_IF_NONE + nav.SOURCE_PATH["hdmi2"]
+    assert route == expected
+
+
+def test_navigate_with_source():
+    nav = Navigator(source="hdmi1")
+    route = nav.navigate_to_source("hdmi2")
+    expected = nav.OPEN_SOURCES_IF_SOURCE_ACTIVE + nav.SOURCE_PATH["hdmi2"]
+    assert route == expected

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -1,0 +1,40 @@
+from pymitv4.control import Control
+from pymitv4.navigator import Navigator
+from pymitv4.tv import TV
+
+
+def test_is_on_with_assumed_state(monkeypatch):
+    monkeypatch.setattr(Control, "check_state", lambda self, ip: True)
+    monkeypatch.setattr(Control, "get_volume", lambda self, ip: 5)
+    tv = TV(ip_address="1.2.3.4", assume_state=True)
+    tv.state = False
+    assert tv.is_on is False
+
+
+def test_is_on_without_assumed_state(monkeypatch):
+    monkeypatch.setattr(Control, "check_state", lambda self, ip: True)
+    monkeypatch.setattr(Control, "get_volume", lambda self, ip: 5)
+    tv = TV(ip_address="1.2.3.4", assume_state=False)
+    assert tv.is_on is True
+
+
+def test_set_source(monkeypatch):
+    monkeypatch.setattr(Control, "get_volume", lambda self, ip: 5)
+    tv = TV(ip_address="1.2.3.4")
+    monkeypatch.setattr(
+        Navigator,
+        "navigate_to_source",
+        lambda self, s: ["enter"],
+    )
+
+    called = {}
+
+    def fake_send(self, keystrokes, wait=False):
+        called["args"] = (keystrokes, wait)
+        return True
+
+    monkeypatch.setattr(TV, "_send_keystroke", fake_send)
+
+    result = tv.set_source("hdmi1")
+    assert result is True
+    assert called["args"] == (["enter"], True)


### PR DESCRIPTION
## Summary
- add unit tests for the package
- show coverage badge in README
- install coverage tools
- run tests with coverage in new GitHub workflow

## Testing
- `isort tests src setup.py --check`
- `flake8 src tests setup.py`
- `pytest --cov=src/pymitv4 --cov-report=xml --cov-report=term -q`


------
https://chatgpt.com/codex/tasks/task_e_6855e0092ae483208188bf2727d649eb

## Summary by Sourcery

Add comprehensive unit tests and configure CI to generate and display test coverage metrics

Enhancements:
- Integrate coverage tracking and badge generation into the project

CI:
- Add GitHub Actions workflow to run tests with coverage, generate a coverage badge, and upload artifacts

Documentation:
- Add coverage badge to the README

Tests:
- Add unit tests for Control, Discover, Navigator, and TV modules with shared test configuration

Chores:
- Include initial coverage.svg file